### PR TITLE
Don't init .auth object until .onLoad

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: gmailr
 Title: Access the 'Gmail' 'RESTful' API
-Version: 1.0.0.9000
+Version: 1.0.0.9001
 Author: Jim Hester
 Maintainer: Jim Hester <james.f.hester@gmail.com>
 Description: An interface to the 'Gmail' 'RESTful' API.  Allows

--- a/R/aaa.R
+++ b/R/aaa.R
@@ -1,1 +1,9 @@
 the <- new.env(parent = emptyenv())
+
+.onLoad <- function(libname, pkgname) {
+
+  .auth <<- gargle::init_AuthState(
+    package     = "gmailr",
+    auth_active = TRUE
+  )
+}

--- a/R/gm-auth.R
+++ b/R/gm-auth.R
@@ -1,9 +1,8 @@
 # This file is the interface between gmailr and the
 # auth functionality in gargle.
-.auth <- gargle::init_AuthState(
-  package     = "gmailr",
-  auth_active = TRUE
-)
+
+# Initialization happens in .onLoad
+.auth <- NULL
 
 # The roxygen comments for these functions are mostly generated from data
 # in this list and template text maintained in gargle.


### PR DESCRIPTION
Creating the .auth object directly at the top-level means the code
from gargle is snapshotted at build time.

This is needed for r-lib/gargle#157, but is a good change even without that PR.