### PR TITLE
Stop requiring a configured oauth client prior to `token_fetch()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,13 +15,34 @@ Version 1.3.0 of gargle introduced some changes around OAuth and gmailr is synci
   - The first argument is now named `client`, which is morally equivalent to the
     previous `app`, i.e. this is essentially a name change.
   - The `key`, `secret`, `appname`, and `app` arguments are deprecated.
-    Our strong recommendation is to use the `path` argument, e.g.:
-  
+  - Our strong recommendation is to use the `path` argument, either explicitly::
     ``` r
     gm_auth_configure(path = "path/to/my-oauth-client.json")
     ```
+    or implicitly:
+    ``` r
+    gm_auth_configure()
+    ```
+    which works because of the new default:
+    `gm_auth_configure(path = gm_default_oauth_client()`.
+* `gm_default_oauth_client()` is a new helper that searches for the JSON file
+  representing an OAuth client in a sequence of locations. The (file)path of
+  least resistance is to place this file in the directory returned by
+  `rappdirs::user_data_dir("gmailr")`. Another alternative is to record its
+  filepath in the `GMAILR_OAUTH_CLIENT` environment variable. For backwards
+  compatibility, the `GMAILR_APP` environment variable is still consulted, but
+  generates a warning (#166).
 
 ## Other changes
+
+* `gm_auth()` no longer checks for an OAuth client before calling
+  `gargle::token_fetch()`. This allows other auth methods to work, which by and
+  large don't need an OAuth client, such as `gargle::credentials_byo_oauth2()`
+  (#160, #186).
+  
+  Since the lack of an OAuth client undoubtedly remains the most common reason
+  for `gm_auth()` to fail, its error message includes some specific content if
+  no OAuth client has been configured.
 
 * `gm_scopes()` can now take a character vector of scopes, each of which can be
   an actual scope or a short alias, e.g., `"gmail.readonly"`, which identifies a
@@ -54,13 +75,6 @@ Version 1.3.0 of gargle introduced some changes around OAuth and gmailr is synci
   affected R versions, the examples are automatically converted to a regular
   section with a note that they might not work.
   
-* `gm_default_oauth_client()` is a new helper that searches for the JSON file
-  representing an OAuth client in a sequence of locations. The (file)path of
-  least resistance is to place this file in the directory returned by
-  `rappdirs::user_data_dir("gmailr")`. Another alternative is to record its
-  filepath in the `GMAILR_OAUTH_CLIENT` environment variable. For backwards
-  compatibility, the `GMAILR_APP` environment variable is still consulted, but
-  generates a warning (#166).
 
 # gmailr 1.0.1
 

--- a/tests/testthat/_snaps/gm_auth.md
+++ b/tests/testthat/_snaps/gm_auth.md
@@ -1,3 +1,47 @@
+# gm_auth() errors if OAuth client is passed to `path`
+
+    Code
+      gm_auth(path = system.file("extdata",
+        "client_secret_installed.googleusercontent.com.json", package = "gargle"))
+    Condition
+      Error in `gm_auth()`:
+      ! `path` does not represent a service account.
+      Did you provide the JSON for an OAuth client instead of for a service account?
+      Use `gm_auth_configure()` to configure the OAuth client.
+
+# gm_auth() errors informatively
+
+    Code
+      gm_auth()
+    Condition
+      Error in `gm_auth()`:
+      ! Can't get Google credentials.
+      x No OAuth client has been configured.
+      i To auth with the user flow, you must register an OAuth client with `gm_auth_configure()`.
+      i See the article "Set up an OAuth client" for how to get a client:
+        <https://gmailr.r-lib.org/dev/articles/oauth-client.html>
+      ! gmailr appears to be running in a non-interactive session and it can't auto-discover credentials.
+        You may need to call `gm_auth()` directly with all necessary specifics.
+      i See gargle's "Non-interactive auth" vignette for more details:
+      i <https://gargle.r-lib.org/articles/non-interactive-auth.html>
+      i For general auth troubleshooting, set `options(gargle_verbosity = "debug")` to see more detailed debugging information.
+
+# gm_auth_configure() works
+
+    Code
+      gm_auth_configure(client = gargle::gargle_client(), path = "PATH")
+    Condition
+      Error in `gm_auth_configure()`:
+      ! Must supply exactly one of `client` and `path`, not both.
+
+---
+
+    Code
+      gm_auth_configure()
+    Condition
+      Error in `gm_auth_configure()`:
+      ! Must supply either `client` or `path`.
+
 # gm_auth_configure() errors for key, secret, appname, app
 
     Code
@@ -15,22 +59,6 @@
       Warning:
       `gm_oauth_app()` was deprecated in gmailr 2.0.0.
       i Please use `gm_oauth_client()` instead.
-
-# gm_auth_configure() works
-
-    Code
-      gm_auth_configure(client = gargle::gargle_client(), path = "PATH")
-    Condition
-      Error in `gm_auth_configure()`:
-      ! Must supply exactly one of `client` and `path`, not both.
-
----
-
-    Code
-      gm_auth_configure()
-    Condition
-      Error in `gm_auth_configure()`:
-      ! Must supply either `client` or `path`.
 
 # gm_scopes() reveals gmail scopes
 

--- a/tests/testthat/helper.R
+++ b/tests/testthat/helper.R
@@ -1,21 +1,7 @@
 if (gargle:::secret_can_decrypt("gmailr")) {
-  # provide the actual token, so we don't need to get into the oauth client
   token <- unserialize(gzcon(rawConnection(
     gargle:::secret_read("gmailr", "gmailr-dev-token")
   )))
-
-  # https://github.com/r-lib/gmailr/issues/160
-  fake_client <- gargle::gargle_oauth_client(
-    id = "PLACEHOLDER",
-    secret = "PLACEHOLDER"
-  )
-  gm_auth_configure(fake_client)
-  # Alternatively, I could do this:
-  # gm_auth_configure(client = token$app)
-  # But that is somewhat misleading, i.e. it suggests that the configured client
-  # needs to match that of the token, which it does not. The configured client
-  # is never needed.
-
   gm_auth(token = token)
 
   # TODO: Think about approaches other than this.


### PR DESCRIPTION
Fixes #160

The basic idea is to let `token_fetch()` fail for someone who wants the user flow AND who has failed to configure an OAuth client. Then, in the `gm_auth()` error message, try to provide enough info to help that user diagnose their problem.

Previously an OAuth client was required, unconditionally, prior to calling `token_fetch()`. The upside is that the user who wants the user flow gets an unequivocal early error message if they haven't configured a client. And this is by far the most common use case.

But the downside is that _no other auth flow_ can work. No BYO token, no service account, no ADC, etc. None of those even need an OAuth client, but they are currently inaccessible because of the unconditional client check. So that has to change.

Here I remove the unconditional check for an OAuth client and, instead, insert specific advice in the `gm_auth()` error message.

While I was working on the message, I also added advice about setting `options(gargle_verbosity = "debug")`.

This change also makes it easier to auth with the dev/testing credentials, which uses BYO token.


