### PR TITLE
Enhancement: Support for Vector or List of Emails for Multiple Recipients

### DIFF
--- a/R/gm_mime.R
+++ b/R/gm_mime.R
@@ -41,6 +41,10 @@ gm_to.mime <- function(x, val, ...) {
   if (missing(val)) {
     return(x$header$To)
   }
+  if (length(val) > 1) {
+    x$header$To <- paste(val, collapse=",")
+    return(x)
+  }
   x$header$To <- val
   x
 }
@@ -61,6 +65,10 @@ gm_cc.mime <- function(x, val, ...) {
   if (missing(val)) {
     return(x$header$Cc)
   }
+  if (length(val) > 1) {
+    x$header$Cc <- paste(val, collapse=",")
+    return(x)
+  }
   x$header$Cc <- val
   x
 }
@@ -70,6 +78,10 @@ gm_cc.mime <- function(x, val, ...) {
 gm_bcc.mime <- function(x, val, ...) {
   if (missing(val)) {
     return(x$header$Bcc)
+  }
+  if (length(val) > 1) {
+   x$header$Bcc <- paste(val, collapse=",")
+   return(x)
   }
   x$header$Bcc <- val
   x


### PR DESCRIPTION
This pull request introduces the ability to pass a vector or list of emails to the function, enabling the creation of an email with multiple recipients. This feature addresses an issue encountered by our team, where there was an assumption that the function could naturally handle a vector/list of emails for sending to multiple recipients. A thorough search revealed no documentation on how to achieve this, indicating a gap in usability for users unfamiliar with the underlying mechanics of the function.

The addition of this feature simplifies the process of including multiple recipients, CCs, and BCCs, making it more accessible and user-friendly, especially for those not versed in the function's inner workings.